### PR TITLE
Reformatted README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#wordpress-digitalchalk-sso-plugin
+# wordpress-digitalchalk-sso-plugin
 
-#Description
+## Description
 
 This is a plugin for Wordpress that enables Single Sign-On to the DigitalChalk LMS
 
-#Installation
+## Installation
 
 Download the latest version of the plugin from the releases directory.  The current version is [wpdcsso-1.0.5.zip](https://github.com/digitalchalk/wordpress-digitalchalk-sso-plugin/raw/master/releases/wpdcsso.1.0.5.zip).
 
@@ -12,22 +12,22 @@ Install the usual way through the plugins option in Wordpress Admin panel.  No c
 
 After installation and plugin activation (in WordPress wp-admin), go to Settings > Plugins > DigitalChalk SSO and set the parameters for the plugin, based on information from your DigitalChalk instructor account.
 
-#Frequently Asked Questions
-#####Q: Should I choose email or username in the settings?
-######A: This setting needs to match what your DigitalChalk account uses.  If you log into DigitalChalk with an email, select email here, regardless of how you log into WordPress.  Note that if you use email, each WordPress user must have an email address in their profile (although it doesn't have to be their username).  If you are unsure if your DigitalChalk account is set to email or username, contact DigitalChalk support.
+## Frequently Asked Questions
+##### Q: Should I choose email or username in the settings?
+###### A: This setting needs to match what your DigitalChalk account uses.  If you log into DigitalChalk with an email, select email here, regardless of how you log into WordPress.  Note that if you use email, each WordPress user must have an email address in their profile (although it doesn't have to be their username).  If you are unsure if your DigitalChalk account is set to email or username, contact DigitalChalk support.
 
 
-###Changelog
-####1.0.5
+### Changelog
+#### 1.0.5
 Fixed ability to pass in Sandbox or Production URLs
 
-####1.0.4
+#### 1.0.4
 Updated to support more metadata fields and PHP7
 
-####1.0.2
+#### 1.0.2
 Stable auto updating release
 
-####1.0
+#### 1.0
 First public release with github updater.
 
 ###Other Info


### PR DESCRIPTION
Github needs spaces after heading hashes. This fixes that.